### PR TITLE
allow channel get for switch, validate 0x61 "a" -> address set

### DIFF
--- a/HBW-CC-DT3-T6/HBW-CC-DT3-T6.ino
+++ b/HBW-CC-DT3-T6/HBW-CC-DT3-T6.ino
@@ -50,10 +50,10 @@
   #define BUTTON A6  // Button fuer Factory-Reset etc.
   #define ADC_BUS_VOLTAGE A7  // analog input to measure bus voltage (optional)
   
-  #define ONEWIRE_PIN	10 // Onewire Bus
+  #define ONEWIRE_PIN	A3 // Onewire Bus
   #define RELAY_1 5
   #define RELAY_2 6
-  #define RELAY_3 7
+  #define RELAY_3 3
   
   #define BLOCKED_TWI_SDA A4  // used by I²C - SDA
   #define BLOCKED_TWI_SCL A5  // used by I²C - SCL
@@ -66,9 +66,9 @@
   #define ADC_BUS_VOLTAGE A7  // analog input to measure bus voltage (optional)
 
   #define ONEWIRE_PIN	10 // Onewire Bus
-  #define RELAY_1 A1
-  #define RELAY_2 A2
-  #define RELAY_3 A3 //NOT_A_PIN
+  #define RELAY_1 5
+  #define RELAY_2 6
+  #define RELAY_3 A2
 
   #include "FreeRam.h"
   #include <HBWSoftwareSerial.h>
@@ -78,7 +78,7 @@
 #define LED LED_BUILTIN        // Signal-LED
 
 
-#define NUMBER_OF_CHAN NUMBER_OF_TEMP_CHAN + (NUMBER_OF_DELTAT_CHAN *3) //+ NUMBER_OF_KEY_CHAN
+#define NUMBER_OF_CHAN NUMBER_OF_TEMP_CHAN + (NUMBER_OF_DELTAT_CHAN *3)
 
 
 struct hbw_config {

--- a/HBW-CC-DT3-T6/readme.txt
+++ b/HBW-CC-DT3-T6/readme.txt
@@ -3,7 +3,7 @@ Homematic Wired Homebrew Delta Temperature and Switch Module
 
 DeltaT Regler + 6 OneWire Temperatursensoren.
 
-Das Modul HHBW-CC-DT3-T6 wurde für eine Ofensteuerung entwickelt. Eine Umwälzpumpe wird ab einer bestimmten Mindesttemperatur und Temperaturdifferenz ein- bzw. Ausgeschaltet.
+Das Modul HBW-CC-DT3-T6 wurde für eine Ofensteuerung entwickelt. Eine Umwälzpumpe wird ab einer bestimmten Mindesttemperatur und Temperaturdifferenz ein- bzw. Ausgeschaltet.
 Basis ist ein Arduino NANO mit RS485-Interface.
 
 Damit FHEM das Homebrew-Device richtig erkennt, muss die hbw_cc_dt3_t6.xml Datei in den Ordner FHEM/lib/HM485/Devices/xml kopiert werden (Das Device gibt sich als HW-Typ 0x9C aus).
@@ -32,7 +32,7 @@ DELTA_TEMP: 0.0 - 25.4°C
 T1_MAX: -200.0 - 200.0°C
 T2_MIN: -200.0 - 200.0°C
 
-* DeltaT wird berechnet als T2 - T1, die Hysterese wird vom delta Wert subtrahiert, wenn die Temperaturdifferenz unterhalb von DELTA_TEMP liegt, ansonsten addiert. Der Ausgang wechselt sofort auf "Aus", wenn T1_MAX überschritten oder T2_MIN unterschritten wird.
+* DeltaT wird berechnet als T2 - T1. Die Hysterese wird vom delta Wert subtrahiert, wenn die Temperaturdifferenz unterhalb von DELTA_TEMP liegt, ansonsten addiert. Der Ausgang wechselt sofort auf "Aus", wenn T1_MAX überschritten oder T2_MIN unterschritten wird.
 
 
 Standard-Pinbelegung:
@@ -42,10 +42,10 @@ Standard-Pinbelegung:
 2  - RS485 Enable
 13 - Status LED
 A6 - Bedientaster (Reset)
-10 - OneWire Bus (parasitäre oder dedizierte Stromversorgung)
+A3 - OneWire Bus (parasitäre oder dedizierte Stromversorgung)
  5 - RELAY_1
  6 - RELAY_2
- 7 - RELAY_3
+ 3 - RELAY_3
 
 
 "Debug"-Pinbelegung:
@@ -55,7 +55,6 @@ A6 - Bedientaster (Reset)
 13 - Status LED
 8  - Bedientaster (Reset)
 10 - OneWire Bus (parasitäre oder dedizierte Stromversorgung)
-A1 - RELAY_1
-A2 - RELAY_2
-A3 - RELAY_3
-  
+5 - RELAY_1
+6 - RELAY_2
+A2 - RELAY_3

--- a/HBW-DIS-Key-4/HBWDisplayLCD.cpp
+++ b/HBW-DIS-Key-4/HBWDisplayLCD.cpp
@@ -168,7 +168,6 @@ void HBWDisplayVChBool::set(HBWDevice* device, uint8_t length, uint8_t const * c
 /* set special input value for a channel, via peering event. */
 void HBWDisplayLine::set(HBWDevice* device, uint8_t length, uint8_t const * const data)
 {
-  HBWDisplayDim::displayWakeUp = true;
   if (length == 2)  // peering has 2 bytes
   {
     if (lastKeyNum == data[1])  // ignore repeated key press
@@ -176,6 +175,8 @@ void HBWDisplayLine::set(HBWDevice* device, uint8_t length, uint8_t const * cons
     else
       lastKeyNum = data[1];
   }
+  
+  HBWDisplayDim::displayWakeUp = true;
   
   if (length > 2 )  // need to set min. 3 characters (should be ok, to set "foo" or even a single variable, like "%1%")
   {
@@ -559,7 +560,7 @@ void HBWDisplayDim::loop(HBWDevice* device, uint8_t channel)
   }
 
   // fixed intervall and not critical... so use millis() with modulo...
-  if (millis() % LCD_BACKLIGHT_UPDATE_INTERVAL == 0)
+  if (millis() % LCD_BACKLIGHT_UPDATE_INTERVAL == 0 || displayWakeUp)
   {
     if (displayWakeUp) {
       displayWakeUp = false;

--- a/HBW-DIS-Key-4/readme.txt
+++ b/HBW-DIS-Key-4/readme.txt
@@ -1,8 +1,6 @@
 Homematic Wired Homebrew Display Module + 4 Key Input
 =====================================================
 
---- still in development ---
-
 Das Modul HBW-DIS-Key-4 bindet ein LCD Character Display an den Bus an. Die Anzahl der Zeilen und Zeichen pro Zeile kann angepasst werden.
 Zusätzlich sind 4 Tasterkanäle vorhanden.
 Die Tasterkanäle unterstützen Direktverknüpfungen (Peering). Ebenso können die virtuellen Switch- und Temperaturkanäle mit Sensoren direkt verknüpft werden.
@@ -13,12 +11,12 @@ Damit FHEM das Homebrew-Device richtig erkennt, muss die Datei hbw-dis-key-4.xml
 
 
 Kanäle:
-1x Display (1*4 bis 4*24 LCD)
-1x Dimmer (Display Hintergrundbeleuchtung)
+1x display "Master Kanal" (mit Konfigurationsmöglichkeit der Displaygröße, 1*4 bis 4*24 LCD)
+1x dimmer (Display Hintergrundbeleuchtung, mit Auto-off & automatischer Helligkeit)
 4x display_line (bei zweizeiligen Displays werden nur die beiden ersten Kanäle genutzt)
-4x Key (Taster, Schalter)
-4x display_v_temp	(Speichert Temperaturmesswerte oder beliebige Werte von -32768 bis 32767)
-4x display_v_switch	(Speichert einen binären Wert, 0 oder 1)
+4x key (Taster)
+4x display_v_temp (Speichert Temperaturmesswerte oder beliebige Werte von -32768 bis 32767)
+4x display_v_switch (Speichert einen binären Wert, 0 oder 1)
 
 
 Für die "display_line" Kanäle, welche je eine Zeile des Displays repräsentieren, kann mit FHEM ein Wert übertragen werden (siehe FHEM RAW Befehle weiter unten) oder es wird einer der vordefinierten Zeilen angezeigt.

--- a/HBW-LC-Sw-12/HBW-LC-Sw-12.xml
+++ b/HBW-LC-Sw-12/HBW-LC-Sw-12.xml
@@ -43,6 +43,12 @@
 	<frame id="ANALOG_EVENT" direction="from_device" event="true" type="#i" channel_field="10">
 		<parameter type="integer" index="11.0" size="2.0" param="ANALOGVALUE"/>
 	</frame>
+	<frame id="SET_LOCK" type="#l" channel_field="11" direction="to_device">
+		<parameter type="integer" index="12.0" size="1.0" param="INHIBIT"/>
+	</frame>
+	<frame id="TOGGLE_INSTALL_TEST" type="#x" channel_field="10" direction="to_device">
+		<parameter type="integer" index="11.0" size="1.0" param="TOGGLE_FLAG"/>
+	</frame>
 </frames>
 
 <channels>

--- a/HBW-SC-10-Dim-6/hbw_sc-10_dim-6.xml
+++ b/HBW-SC-10-Dim-6/hbw_sc-10_dim-6.xml
@@ -920,14 +920,21 @@
 				</physical>
 				<conversion type="action_key_counter" counter_size="6" sim_counter="SIM_COUNTER"/>
 			</parameter>
-			<!--<parameter id="SENSOR" operations="read,event" control="DOOR_SENSOR.STATE">
+			<parameter id="SENSOR" operations="read,event" control="DOOR_SENSOR.STATE">
 				<logical type="boolean" default="false"/>
-				<physical type="integer" interface="command" value_id="STATE">
+				<physical type="integer" interface="command" value_id="LEVEL">
 					<get request="LEVEL_GET" response="INFO_LEVEL"/>
 					<event frame="INFO_LEVEL" auth_violate_policy="reject"/>
 				</physical>
-				<conversion type="boolean_integer" threshold="1" false="0" true="255"/>
-			</parameter> -->
+				<!--<conversion type="boolean_integer" threshold="1" false="0" true="200"/>-->
+			</parameter>
+			<!--<parameter id="SENSOR" operations="read,event" control="DOOR_SENSOR.STATE">
+				<logical type="boolean"/>
+				<physical type="integer" interface="command" value_id="STATE">
+					<event frame="STATE_LEVEL" auth_violate_policy="reject"/>
+					<get request="LEVEL_GET" response="STATE_LEVEL"/>
+				</physical>
+			</parameter>-->
 			<parameter id="INSTALL_TEST" operations="event" ui_flags="internal">
 				<logical type="action"/>
 				<physical type="integer" interface="command" value_id="TEST_COUNTER">

--- a/libraries/src/HBWBlind.cpp
+++ b/libraries/src/HBWBlind.cpp
@@ -36,9 +36,9 @@ HBWChanBl::HBWChanBl(uint8_t _blindDir, uint8_t _blindAct, hbw_config_blind* _co
 
 // channel specific settings or defaults
 void HBWChanBl::afterReadConfig() {
-    if (config->blindTimeTopBottom == 0xFFFF) config->blindTimeTopBottom = 200;
-    if (config->blindTimeBottomTop == 0xFFFF) config->blindTimeBottomTop = 200;
-    if (config->blindTimeChangeOver == 0xFF) config->blindTimeChangeOver = 20;
+    if (config->blindTimeTopBottom == 0xFFFF) config->blindTimeTopBottom = 500;
+    if (config->blindTimeBottomTop == 0xFFFF) config->blindTimeBottomTop = 500;
+    if (config->blindTimeChangeOver == 0xFF) config->blindTimeChangeOver = 5;
 }
 
 void HBWChanBl::set(HBWDevice* device, uint8_t length, uint8_t const * const data) {

--- a/libraries/src/HBWKey.cpp
+++ b/libraries/src/HBWKey.cpp
@@ -38,6 +38,17 @@ void HBWKey::afterReadConfig(){
 };
 
 
+/* standard public function - returns length of data array. Data array contains current channel reading */
+#ifdef ENABLE_SENSOR_STATE
+uint8_t HBWKey::get(uint8_t* data) {
+  
+  (*data) = keyPressedMillis ? 200 : 0;  // use keyPressedMillis, that already reflect activeHigh and inverted option
+  (*data++) = 0;  // state flags not used, but included in INFO_LEVEL frame type
+  return 2;
+};
+#endif
+
+
 void HBWKey::loop(HBWDevice* device, uint8_t channel) {
   
   if (!config->n_input_locked)  return;  // skip locked channels

--- a/libraries/src/HBWKey.cpp
+++ b/libraries/src/HBWKey.cpp
@@ -41,10 +41,9 @@ void HBWKey::afterReadConfig(){
 /* standard public function - returns length of data array. Data array contains current channel reading */
 #ifdef ENABLE_SENSOR_STATE
 uint8_t HBWKey::get(uint8_t* data) {
-  
-  (*data) = keyPressedMillis ? 200 : 0;  // use keyPressedMillis, that already reflect activeHigh and inverted option
-  (*data++) = 0;  // state flags not used, but included in INFO_LEVEL frame type
-  return 2;
+  /* make input state available with DOOR_SENSOR.STATE control. Use Frame INFO_LEVEL or STATE_LEVEL */
+  (*data) =  buttonState ? 200 : 0;
+  return 1;
 };
 #endif
 
@@ -56,8 +55,7 @@ void HBWKey::loop(HBWDevice* device, uint8_t channel) {
   uint32_t now = millis();
   if (now == 0) now = 1;  // do not allow time=0 for the below code // AKA  "der Teufel ist ein Eichhoernchen"
   
-  bool buttonState = (digitalRead(pin) ^ !config->n_inverted);
-  buttonState = activeHigh ^ buttonState;
+  buttonState = activeHigh ^ ((digitalRead(pin) ^ !config->n_inverted));
   
   switch (config->input_type) {
     case DOORSENSOR:

--- a/libraries/src/HBWKey.h
+++ b/libraries/src/HBWKey.h
@@ -13,6 +13,7 @@
 // SWITCH        > sends a short KeyEvent, each time the input (e.g. wall switch) changes the polarity
 // PUSHBUTTON    > sends a short KeyEvent on short press and (repeated) long KeyEvent on long press
 
+#define ENABLE_SENSOR_STATE  // allow to query key channels as SENSOR (returns DOOR_SENSOR.STATE - open/closed)
 
 // config, address step 2
 struct hbw_config_key {
@@ -30,6 +31,7 @@ class HBWKey : public HBWChannel {
   public:
     HBWKey(uint8_t _pin, hbw_config_key* _config, boolean _activeHigh = false);
     virtual void loop(HBWDevice*, uint8_t channel);
+    virtual uint8_t get(uint8_t* data);
     virtual void afterReadConfig();
     
     enum InputType

--- a/libraries/src/HBWKey.h
+++ b/libraries/src/HBWKey.h
@@ -48,10 +48,11 @@ class HBWKey : public HBWChannel {
     uint32_t lastSentLong;      // Zeit, zu der das letzte Mal longPress gesendet wurde
     uint8_t keyPressNum;
     hbw_config_key* config;
+    boolean buttonState;
     boolean oldButtonState;
     boolean activeHigh;    // activeHigh=true -> input active high, else active low
     
-    static const uint32_t KEY_DEBOUNCE_TIME = 65;  // ms
+    static const uint32_t KEY_DEBOUNCE_TIME = 85;  // ms
     static const uint32_t SWITCH_DEBOUNCE_TIME = 145;  // ms
     static const uint32_t DOORSENSOR_DEBOUNCE_TIME = 330;  // ms
 };

--- a/libraries/src/HBWired.cpp
+++ b/libraries/src/HBWired.cpp
@@ -46,6 +46,7 @@ void HBWDevice::setOwnAddress(uint32_t address) {
   ownAddress = address;
   randomSeed(ownAddress);
   minIdleTime = random(DIFS_CONSTANT, DIFS_CONSTANT+DIFS_RANDOM);
+  pendingActions.announced = false;	// (re)send announce message
 }
 
 
@@ -454,9 +455,13 @@ void HBWDevice::processEvent(byte const * const frameData, byte frameDataLength,
           case 'z':                                              // start discovery mode
             pendingActions.zeroCommunicationActive = true;
             break;
-            //case 'K':  // 0x4B Key-Event
+          // case 'K':  // 0x4B Key-Event
             // broadcast key events sind für long_press interressant
             //  if (frameDataLength == 4) {...}
+			// if (frameData[3] & 0x01) {    // long press broadcast only
+              // receiveKeyEvent(senderAddress, frameData[1], frameData[2], frameData[3] >>2, true);
+			// }
+            // break;
         }
         return;
       };
@@ -811,7 +816,6 @@ void HBWDevice::determineSerial(byte* buf) {
 void HBWDevice::readConfig() {         // read config from EEPROM	
    // read EEPROM
    readEEPROM(config, 0x01, configSize);
-   
    // turn around central address
    uint32_t addr = *((uint32_t*)(config + 1));
    for(uint8_t i = 0; i < 4; i++)

--- a/libraries/src/HBWired.cpp
+++ b/libraries/src/HBWired.cpp
@@ -46,7 +46,7 @@ void HBWDevice::setOwnAddress(uint32_t address) {
   ownAddress = address;
   randomSeed(ownAddress);
   minIdleTime = random(DIFS_CONSTANT, DIFS_CONSTANT+DIFS_RANDOM);
-  pendingActions.announced = false;	// (re)send announce message
+  pendingActions.announced = false;	// (re)send broadcast announce message
 }
 
 
@@ -486,7 +486,12 @@ void HBWDevice::processEvent(byte const * const frameData, byte frameDataLength,
       switch(frameData[0]){
          case '@':             // 0x40                 // HBW-specifics
            if(frameData[1] == 'a' && frameDataLength == 6) {  // 0x61 "a" -> address set
-        	 // TODO: Avoid "central" addresses (like 0000...)
+        	 hbwdebug(F("@: Set Address\n"));
+        	 // Avoid "central" addresses (like 0000... 000FF)
+        	 if (frameData[2] == 0 && frameData[3] == 0 && frameData[4] == 0) {
+        	 	 hbwdebug(F("@: rejected\n"));
+        	 	 break;
+        	 }
         	 for(byte i = 0; i < 4; i++)
         	   writeEEPROM(E2END - 3 + i, frameData[i + 2], true);
            };
@@ -905,7 +910,6 @@ HBWDevice::HBWDevice(uint8_t _devicetype, uint8_t _hardware_version, uint16_t _f
    configPin = NOT_A_PIN;  //inactive by default
    configButtonStatus = 0;
    readConfig();	// read config
-   pendingActions.announced = false;	// was initial broadcast announce message send?
    pendingActions.zeroCommunicationActive = false;	// will be activated by START_ZERO_COMMUNICATION = 'z' command
 }
   


### PR DESCRIPTION
- validate 0x61 "a" -> address set
- resend announce message after own address change
- allow to query key channels as SENSOR (returns open/closed) [can be disabled with ENABLE_SENSOR_STATE definement in HBWKey.h]
- some small fixes on other devices
