### PR TITLE
watchdog timer enabled by default

### DIFF
--- a/HBW-CC-DT3-T6/HBW-CC-DT3-T6.ino
+++ b/HBW-CC-DT3-T6/HBW-CC-DT3-T6.ino
@@ -20,10 +20,13 @@
 // - add config for output change frequency (CYCLE_TIME)
 // v0.45
 // - using config LED for Tx & Rx indicator
+// v0.50
+// - allow to set HBWDeltaT output when mode is IDLE/inactive (no temperature received)
+// - option for error state (set OFF/ON), when error_temperature is received
 
 
 #define HARDWARE_VERSION 0x01
-#define FIRMWARE_VERSION 0x002D
+#define FIRMWARE_VERSION 0x0032
 #define HMW_DEVICETYPE 0x9C //device ID (make sure to import .xml into FHEM)
 
 #define NUMBER_OF_TEMP_CHAN 6   // input channels - 1-wire temperature sensors

--- a/HBW-CC-DT3-T6/HBWDeltaT.h
+++ b/HBW-CC-DT3-T6/HBWDeltaT.h
@@ -42,7 +42,8 @@ struct hbw_config_DeltaT {
   uint8_t n_enableHysMaxT1:1;  // apply hysteresis on maxT1, 1=off (default) 0=on
   uint8_t n_enableHysMinT2:1;  // apply hysteresis on minT2, 1=off (default) 0=on
   uint8_t n_enableHysOFF:1;  // apply hysteresis on OFF transition, too. 1=off (default) 0=on
-  uint8_t :2;     //fillup
+  uint8_t error_state:1;  // set output OFF or ON at error state (defaut OFF)
+  uint8_t :1;     //fillup
 };
 
 // config of one DeltaTx channel, address step 1
@@ -74,7 +75,7 @@ class HBWDeltaT : public HBWChannel {
     HBWDeltaT(uint8_t _pin, HBWDeltaTx* _delta_t1, HBWDeltaTx* _delta_t2, hbw_config_DeltaT* _config);
     virtual void loop(HBWDevice*, uint8_t channel);
     virtual uint8_t get(uint8_t* data);
-    //virtual void set(HBWDevice*, uint8_t length, uint8_t const * const data); //TODO: allow to set when mode inactive?
+    virtual void set(HBWDevice*, uint8_t length, uint8_t const * const data);
     virtual void afterReadConfig();
 
   private:

--- a/HBW-CC-DT3-T6/HBW_CC_DT3_T6.xml
+++ b/HBW-CC-DT3-T6/HBW_CC_DT3_T6.xml
@@ -4,7 +4,7 @@
 	<type name="RS485 3 Channel Delta Temperature and 6 One Wire Channel Temperature Module" id="HBW-CC-DT3-T6" priority="2">
 		<parameter index="0" size="1" const_value="0x9C"/><!--HMW_DEVICETYPE-->
 		<parameter index="1" size="1" const_value="1"/><!--HARDWARE_VERSION-->
-		<parameter const_value="0x001E" size="2" cond_op="GE" index="2"/><!--min FIRMWARE_VERSION-->
+		<parameter const_value="0x0028" size="2" cond_op="GE" index="2"/><!--min FIRMWARE_VERSION-->
 	</type>
 </supported_types>
 
@@ -296,6 +296,15 @@
 				<conversion type="integer_integer_map">
 					<value_map to_device="false" from_device="true" parameter_value="5" device_value="0x7"/>
 				</conversion>
+			</parameter>
+			<parameter id="ERROR_STATE">
+				<logical type="option">
+					<option id="ON"/>
+					<option id="OFF" default="true"/>
+				</logical>
+				<physical type="integer" size="0.1" interface="eeprom">
+					<address index="+6.6"/>
+				</physical>
 			</parameter>
 		</paramset>
 		<paramset type="LINK" id="hmw_deltat_ch_link" peer_param="ACTUATOR" channel_param="CHANNEL" count="32" address_start="0x100" address_step="6">

--- a/HBW-CC-DT3-T6/readme.txt
+++ b/HBW-CC-DT3-T6/readme.txt
@@ -15,8 +15,8 @@ DS18B20 Gerätecode 0x28
 DS1822  Gerätecode 0x22
 
 Direktes Peering:
-Die tempsensor Kanäle können mit delta_t1, delta_t2 verknüpft werden, oder anderen externen Kanälen. (delta_t1/delta_t2 sollte nur jeweils ein Sensor zugewiesen werden!)
-Der delta_t Kanaltyp kann mit Aktor Kanälen verknüpft werden, z.B. externe Relais. (delta_t sendet short/long keyEvents)
+Die tempsensor Kanäle können mit delta_t1, delta_t2 verknüpft werden, oder anderen externen Kanälen. (delta_t1/delta_t2 sollte nur jeweils ein Temperatursensor zugewiesen werden!)
+Der delta_t Kanaltyp kann mit Aktor Kanälen verknüpft werden, z.B. externe Relais, Display, o.ä.. (delta_t sendet short/long keyEvents)
 
 
 Kanäle:
@@ -27,10 +27,11 @@ Kanäle:
 
 
 DeltaT Konfiguration:
-HYSTERESIS: 0.0 - 3.0°C
-DELTA_TEMP: 0.0 - 25.4°C
-T1_MAX: -200.0 - 200.0°C
-T2_MIN: -200.0 - 200.0°C
+* HYSTERESIS: 0.0 - 3.0°C
+* DELTA_TEMP: 0.0 - 25.4°C
+* T1_MAX: -200.0 - 200.0°C
+* T2_MIN: -200.0 - 200.0°C
+* CYCLE_TIME: 5 - 40 Sekunden
 
 * DeltaT wird berechnet als T2 - T1. Die Hysterese wird vom delta Wert subtrahiert, wenn die Temperaturdifferenz unterhalb von DELTA_TEMP liegt, ansonsten addiert (Als Option zuschaltbar). Der Ausgang wechselt sofort auf "Aus", wenn T1_MAX überschritten oder T2_MIN unterschritten wird. Alternativ kann hier auch die Hysterese angewendet werden.
 

--- a/libraries/src/HBWired.h
+++ b/libraries/src/HBWired.h
@@ -19,7 +19,7 @@
 // #define Support_HBWLink_InfoEvent
 
 // #define Support_ModuleReset  // enable reset comand, to restart module "!!" (hexstring 2121)
-// #define Support_WDT  // enable 1 second watchdog timer
+#define Support_WDT  // enable 1 second watchdog timer
 
 
 class HBWDevice;
@@ -151,7 +151,7 @@ class HBWDevice {
 		NO_ACK		//   2 -> three times no ACK (cannot occur for broadcasts or ACKs)
 	};
 
-  private:							 
+  private:
 	uint8_t numChannels;    // number of channels
 	HBWChannel** channels;  // channels
 	HBWLinkSender* linkSender;
@@ -228,7 +228,7 @@ class HBWDevice {
 	void crc16Shift(uint8_t, uint16_t*);
 
 	void readAddressFromEEPROM();
-	void determineSerial(uint8_t*);
+	void determineSerial(uint8_t*, uint32_t address);
 
 	void processEventGetLevel(uint8_t channel, uint8_t command);
 	void processEventSetLock(uint8_t channel, boolean inhibit);


### PR DESCRIPTION
- sprintf replaced, saving lot of flash (approx. 1500 bytes)
- watchdog timer enabled by default
- small update to HBW-CC-DT3-T6
