### PR TITLE
few fixes and added *SEND_RETRIES into HBWired.h

### DIFF
--- a/HBW-CC-DT3-T6/HBW-CC-DT3-T6.ino
+++ b/HBW-CC-DT3-T6/HBW-CC-DT3-T6.ino
@@ -26,7 +26,7 @@
 
 
 #define HARDWARE_VERSION 0x01
-#define FIRMWARE_VERSION 0x0032
+#define FIRMWARE_VERSION 0x0033
 #define HMW_DEVICETYPE 0x9C //device ID (make sure to import .xml into FHEM)
 
 #define NUMBER_OF_TEMP_CHAN 6   // input channels - 1-wire temperature sensors

--- a/HBW-CC-DT3-T6/HBWDeltaT.cpp
+++ b/HBW-CC-DT3-T6/HBWDeltaT.cpp
@@ -170,7 +170,6 @@ bool HBWDeltaT::setOutput(HBWDevice* device, uint8_t channel)
   digitalWrite(pin, (!nextState ^ config->n_inverted));     // set local output
 
   // allow peering with external switches
-  if ( (keyPressNum & 0x3F) == 0 ) keyPressNum = 1;  // do not send keyNum=0
   if (device->sendKeyEvent(channel, keyPressNum, !nextState) != HBWDevice::BUS_BUSY) {
     keyPressNum++;
     currentState = nextState; // retry, as long as the bus is busy (retry interval: 'output_change_wait_time')

--- a/HBW-DIS-Key-4/HBW-DIS-Key-4.ino
+++ b/HBW-DIS-Key-4/HBW-DIS-Key-4.ino
@@ -19,7 +19,7 @@
 
 
 #define HARDWARE_VERSION 0x01
-#define FIRMWARE_VERSION 0x0016
+#define FIRMWARE_VERSION 0x0017
 #define HMW_DEVICETYPE 0x71 //device ID (make sure to import hbw-dis-key-4.xml into FHEM)
 
 

--- a/HBW-DIS-Key-4/HBWDisplayLCD.cpp
+++ b/HBW-DIS-Key-4/HBWDisplayLCD.cpp
@@ -129,12 +129,15 @@ void HBWDisplayVChBool::set(HBWDevice* device, uint8_t length, uint8_t const * c
 {
   /* just store the new value. The display loop can fetch it, when needed */
   
-  if (length == 2)
+  if (length == 3)
   {
-    if (lastKeyNum == data[1])  // ignore repeated key press
+    uint8_t currentKeyNum = data[1];
+    bool sameLastSender = data[2];
+    
+    if (lastKeyNum == currentKeyNum && sameLastSender)  // ignore repeated key press from the same sender
       return;
     else
-      lastKeyNum = data[1];
+      lastKeyNum = currentKeyNum;
   }
     
   if (data[0] > 200)    // toggle

--- a/HBW-DIS-Key-4/HBWLinkInfoKeyEventActuator.h
+++ b/HBW-DIS-Key-4/HBWLinkInfoKeyEventActuator.h
@@ -24,6 +24,9 @@ class HBWLinkInfoKeyEventActuator : public HBWLinkReceiver {
       void receiveKeyEvent(HBWDevice* device, uint32_t senderAddress, uint8_t senderChannel, 
                            uint8_t targetChannel, uint8_t keyPressNum, boolean longPress);
   private:
+      uint32_t lastSenderAddress;
+      uint8_t lastSenderChannel;
+
       static const uint8_t EEPROM_SIZE = 7;   // "address_step" in XML
 };
 

--- a/HBW-DIS-Key-4/HBWLinkInfoKeyEventActuator.hpp
+++ b/HBW-DIS-Key-4/HBWLinkInfoKeyEventActuator.hpp
@@ -50,8 +50,15 @@ void HBWLinkInfoKeyEventActuator<numLinks, eepromStart>::receiveKeyEvent(HBWDevi
   uint32_t sndAddrEEPROM;
   uint8_t channelEEPROM;
   uint8_t actionType;
-  uint8_t data[2];
+  uint8_t data[3];
   data[1] = keyPressNum;
+  data[2] = false;
+  
+  if (senderAddress == lastSenderAddress && senderChannel == lastSenderChannel) {
+    data[2] = true;  // true, as this was the same sender (source device & channel) - sameLastSender
+  }
+  lastSenderAddress = senderAddress;
+  lastSenderChannel = senderChannel;
   
   // read what to do from EEPROM
   for(byte i = 0; i < numLinks; i++) {

--- a/HBW-LC-Sw-8_AdvancedPeering/HBW-LC-Sw-8.xml
+++ b/HBW-LC-Sw-8_AdvancedPeering/HBW-LC-Sw-8.xml
@@ -4,12 +4,13 @@
 	<type priority="2" id="HBW-LC-Sw-8" name="RS485 Homebrew switch actuator 8-channel">
 		<parameter const_value="0x83" size="1" index="0"/>
 		<parameter const_value="1" size="1" index="1"/>
+		<parameter const_value="0x0067" size="2" cond_op="GE" index="2"/><!--FIRMWARE_VERSION-->
 	</type>
 </supported_types>
 
 <paramset id="HBW_LC_Sw_8_dev_master" type="MASTER">
 	<parameter id="LOGGING_TIME">
-		<logical type="float" unit="s" default="2.0" max="25.5" min="0.1"/>
+		<logical type="float" unit="s" default="5.0" max="25.5" min="0.1"/>
 		<physical size="1.0" type="integer" interface="eeprom">
 			<address index="0x0001"/>
 		</physical>
@@ -58,7 +59,6 @@
 					<address index="+0"/>
 				</physical>
 			</parameter>
-			
 			<parameter id="OUTPUT_LOCKED">
 				<logical type="boolean" default="false"/>
 				<physical size="0.1" type="integer" interface="eeprom">

--- a/HBW-LC-Sw-8_AdvancedPeering/HBW-LC-Sw-8_AdvancedPeering.ino
+++ b/HBW-LC-Sw-8_AdvancedPeering/HBW-LC-Sw-8_AdvancedPeering.ino
@@ -22,7 +22,7 @@
 
 
 #define HARDWARE_VERSION 0x01
-#define FIRMWARE_VERSION 0x0068
+#define FIRMWARE_VERSION 0x0069
 #define HMW_DEVICETYPE 0x83
 
 #define NUM_CHANNELS 8
@@ -44,28 +44,40 @@
 #include <HBWSwitchAdvanced.h>
 
 
+// Pins
+#define LED LED_BUILTIN      // Signal-LED
+
 #ifdef USE_HARDWARE_SERIAL
   #define RS485_TXEN 2  // Transmit-Enable
+  #define BUTTON A6  // Button fuer Factory-Reset etc.
+  
+  #define SWITCH1_PIN A4  // Ausgangpins fuer die Relais
+  #define SWITCH2_PIN A2
+  #define SWITCH3_PIN A0
+  #define SWITCH4_PIN 10
+  #define SWITCH5_PIN A1
+  #define SWITCH6_PIN 9
+  #define SWITCH7_PIN A3
+  #define SWITCH8_PIN 5
+  
 #else
   #define RS485_RXD 4
   #define RS485_TXD 2
   #define RS485_TXEN 3  // Transmit-Enable
+  #define BUTTON 8  // Button fuer Factory-Reset etc.
+
+  #define SWITCH1_PIN A0  // Ausgangpins fuer die Relais
+  #define SWITCH2_PIN A1
+  #define SWITCH3_PIN A2
+  #define SWITCH4_PIN A3
+  #define SWITCH5_PIN A4
+  #define SWITCH6_PIN A5
+  #define SWITCH7_PIN 10
+  #define SWITCH8_PIN 11
   
   HBWSoftwareSerial rs485(RS485_RXD, RS485_TXD); // RX, TX
 #endif
 
-
-// Pins
-#define BUTTON 8  // Button fuer Factory-Reset etc.
-#define LED LED_BUILTIN      // Signal-LED
-#define SWITCH1_PIN A0  // Ausgangpins fuer die Relais
-#define SWITCH2_PIN A1
-#define SWITCH3_PIN A2
-#define SWITCH4_PIN A3
-#define SWITCH5_PIN A4
-#define SWITCH6_PIN A5
-#define SWITCH7_PIN 10
-#define SWITCH8_PIN 11
 
 
 struct hbw_config {
@@ -97,7 +109,7 @@ class HBSwDevice : public HBWDevice {
 
 // device specific defaults
 void HBSwDevice::afterReadConfig() {
-  if(hbwconfig.logging_time == 0xFF) hbwconfig.logging_time = 20;
+  if(hbwconfig.logging_time == 0xFF) hbwconfig.logging_time = 50;
 };
 
 
@@ -151,4 +163,5 @@ void setup()
 void loop()
 {
   device->loop();
+  POWERSAVE();  // go sleep a bit
 };

--- a/HBW-LC-Sw-8_AdvancedPeering/readme.txt
+++ b/HBW-LC-Sw-8_AdvancedPeering/readme.txt
@@ -1,5 +1,5 @@
-Homematic Wired Homebrew Relaismodul 8fach
-==============================================
+Homematic Wired Homebrew Relaismodul 8-fach
+===========================================
 
 Das Modul HBW-LC-Sw-8 schaltet bis zu 8 angeschlossene Relais.
 Basis ist ein Arduino NANO mit RS485-Interface.
@@ -11,13 +11,30 @@ Maximale Ein-/Ausschaltdauer, Ein-/Ausschaltverzögerung, jeweils: 63000 Sekunden
 Damit FHEM das Homebrew-Device richtig erkennt, muss die HBW-LC-Sw-8.xml Datei in den Ordner FHEM/lib/HM485/Devices/xml kopiert werden (Das Device gibt sich als HW-Typ 0x83 aus).
 
 Standard-Pinbelegung:
-4 - Rx RS485
-2 - Tx RS485
-3 - RS485 Enable
+(Seriell über USART - #define USE_HARDWARE_SERIAL)
+0  - Rx RS485
+1  - Tx RS485
+2  - RS485 Enable
 13 - Status LED
-0 - Rx Debug
-1 - Tx Debug
-8 - Bedientaster (Reset)
+A6 - Bedientaster (Reset)
+A4 - Relais 1
+A2 - Relais 2
+A0 - Relais 3
+10 - Relais 4
+A1 - Relais 5
+ 9 - Relais 6
+A3 - Relais 7
+ 5 - Relais 8
+
+
+"Debug"-Pinbelegung:
+ 4 - Rx RS485
+ 2 - Tx RS485
+ 3 - RS485 Enable
+13 - Status LED
+ 0 - Rx Debug
+ 1 - Tx Debug
+ 8 - Bedientaster (Reset)
 A0 - Relais 1
 A1 - Relais 2
 A2 - Relais 3

--- a/libraries/src/HBWLinkInfoEventSensor.hpp
+++ b/libraries/src/HBWLinkInfoEventSensor.hpp
@@ -40,7 +40,7 @@ void HBWLinkInfoEventSensor<numLinks, eepromStart>::sendInfoEvent(HBWDevice* dev
 			// external peering
 			// TODO: If bus busy, then try to repeat. ...aber zuerst feststellen, wie das die Original-Module machen (bzw. hier einfach so lassen)
 			/* byte result = */ 
-			device->sendInfoEvent(srcChan, length, data, addrEEPROM, channelEEPROM, !NEED_IDLE_BUS, 1);  // free/idle bus was checked before calling sendInfoEvent. Send peer message only once
+			device->sendInfoEvent(srcChan, length, data, addrEEPROM, channelEEPROM, !NEED_IDLE_BUS, PEER_SEND_RETRIES);  // free/idle bus was checked before calling sendInfoEvent - by sending a broadcast message
 		};
 	}; 
 }

--- a/libraries/src/HBWLinkKey.hpp
+++ b/libraries/src/HBWLinkKey.hpp
@@ -42,7 +42,7 @@ void HBWLinkKey<numLinks, eepromStart>::sendKeyEvent(HBWDevice* device, uint8_t 
 			// external peering
 			// TODO: If bus busy, then try to repeat. ...aber zuerst feststellen, wie das die Original-Module machen (bzw. hier einfach so lassen)
 			/* byte result = */ 
-			device->sendKeyEvent(srcChan, keyPressNum, longPress, addrEEPROM, channelEEPROM, !NEED_IDLE_BUS, 1);  // free/idle bus was checked before calling sendKeyEvent - by broadcast message. Send peer message only once
+			device->sendKeyEvent(srcChan, keyPressNum, longPress, addrEEPROM, channelEEPROM, !NEED_IDLE_BUS, PEER_SEND_RETRIES);  // free/idle bus was checked before calling sendKeyEvent - by sending a broadcast message
 		};
 	}; 
 }

--- a/libraries/src/HBWired.h
+++ b/libraries/src/HBWired.h
@@ -89,6 +89,9 @@ class HBWLinkReceiver {
 #define MAX_RX_FRAME_LENGTH 64
 static const boolean NEED_IDLE_BUS = true;  // use for sendFrame
 
+#define DEFAULT_SEND_RETRIES 3
+#define PEER_SEND_RETRIES 1  // Send peer message only once
+
 
 // The HBWired-Device
 class HBWDevice {
@@ -130,7 +133,7 @@ class HBWDevice {
     virtual uint8_t sendKeyEvent(uint8_t channel, uint8_t keyPressNum, boolean longPress);
 	// Key Event Routine mit Target fuer LinkSender 
     virtual uint8_t sendKeyEvent(uint8_t channel, uint8_t keyPressNum, boolean longPress,
-				uint32_t target_address, uint8_t target_channel, boolean busState = NEED_IDLE_BUS, uint8_t retries = 3);
+				uint32_t target_address, uint8_t target_channel, boolean busState = NEED_IDLE_BUS, uint8_t retries = DEFAULT_SEND_RETRIES);
     // Key-Event senden mit Geraetespezifischen Daten (nur Broadcast)
     virtual uint8_t sendKeyEvent(uint8_t srcChan, uint8_t length, void* data);
  								 
@@ -169,7 +172,7 @@ class HBWDevice {
 	//   0 -> ok
 	//   1 -> bus not idle (only if onlyIfIdle)
 	//   2 -> three times no ACK (cannot occur for broadcasts or ACKs)
-	uint8_t sendFrame(boolean onlyIfIdle = false, uint8_t retries = 3);
+	uint8_t sendFrame(boolean onlyIfIdle = false, uint8_t retries = DEFAULT_SEND_RETRIES);
 	void sendAck();  // ACK fuer gerade verarbeitete Message senden
 
 	// eigene Adresse setzen und damit auch random seed


### PR DESCRIPTION
Small fixes / update for HBW-CC-DT3-T6, HBW-DIS-Key-4 and HBW-LC-Sw-8_AdvancedPeering

Send retry count centrally configurable from HBWired.h (so default and special peering config can be changed easily)
```
#define DEFAULT_SEND_RETRIES 3
#define PEER_SEND_RETRIES 1  // Send peer message only once
```