### PR TITLE
allow different "loggingTime" for setFeedback

### DIFF
--- a/HBW-SC-10-Dim-6/HBW-SC-10-Dim-6.ino
+++ b/HBW-SC-10-Dim-6/HBW-SC-10-Dim-6.ino
@@ -35,7 +35,7 @@
 
 
 #define HARDWARE_VERSION 0x01
-#define FIRMWARE_VERSION 0x003E
+#define FIRMWARE_VERSION 0x003F
 #define HMW_DEVICETYPE 0x96 //device ID (make sure to import hbw_io-10_dim-6.xml into FHEM)
 
 #define NUMBER_OF_INPUT_CHAN 10   // input channel - pushbutton, key, other digital in

--- a/HBW-Sen-DB-4/HBW-Sen-DB-4.ino
+++ b/HBW-Sen-DB-4/HBW-Sen-DB-4.ino
@@ -16,7 +16,7 @@
 
 
 #define HARDWARE_VERSION 0x01
-#define FIRMWARE_VERSION 0x000C
+#define FIRMWARE_VERSION 0x000D
 #define HMW_DEVICETYPE 0x98 //device ID (make sure to import hbw-dis-key-4.xml into FHEM)
 
 // + 1 türsummer?
@@ -34,7 +34,6 @@
 
 // HB Wired protocol and module
 #include <HBWired.h>
-//#include <HBWKey.h>
 #include <HBWLinkKey.h>
 #include "HBWKeyDoorbell.h"
 #include <HBWDimBacklight.h>
@@ -46,9 +45,9 @@
   #define BUTTON A6  // Button fuer Factory-Reset etc.
   
   #define BUTTON_1 8
-  #define BUTTON_2 12
-  #define BUTTON_3 7
-  #define BUTTON_4 4
+  #define BUTTON_2 7
+  #define BUTTON_3 4
+  #define BUTTON_4 A1
 
   //#define BUZZER 6
   
@@ -108,11 +107,9 @@ HBWDevice* device = NULL;
 
 void setup()
 {
-   channels[0] = new HBWDimBacklight(&(hbwconfig.BlDimCfg[0]), BACKLIGHT_PWM, LDR_PIN);
-   //channels[1] = new HBWAnalogBrightness(&(hbwconfig.brightnessCfg[0]), LDR_PIN);
-   //channels[0] = new HBWDimBacklight(&(hbwconfig.BlDimCfg[0]), BACKLIGHT_PWM, channels[1]);
+  channels[0] = new HBWDimBacklight(&(hbwconfig.BlDimCfg[0]), BACKLIGHT_PWM, LDR_PIN);
 
-   
+  
   static const byte BUTTON_PIN[] = {BUTTON_1, BUTTON_2, BUTTON_3, BUTTON_4};
   
  #if (NUMBER_OF_KEY_CHAN == 4)

--- a/HBW-Sen-DB-4/readme.txt
+++ b/HBW-Sen-DB-4/readme.txt
@@ -26,9 +26,9 @@ Standard-Pinbelegung:
 13 - Status LED
 A6 - Bedientaster (Reset)
 8  - BUTTON_1
-12 - BUTTON_2
-7  - BUTTON_3
-4  - BUTTON_4
+7  - BUTTON_2
+4  - BUTTON_3
+A1 - BUTTON_4
 9  - BACKLIGHT (PWM Pin!)
 A0 - LDR (Photo R (ADC Pin!))
 

--- a/libraries/src/HBWSenSC.h
+++ b/libraries/src/HBWSenSC.h
@@ -44,15 +44,12 @@ class HBWSenSC : public HBWChannel {
     boolean initDone;
     boolean activeHigh;    // activeHigh=true -> input active high, else active low
 
-    uint8_t nextFeedbackDelay;  // use factor 10 here, to save memory
-    uint32_t lastFeedbackTime;
-    
     inline boolean readScInput() {
       boolean reading  = (digitalRead(pin) ^ config->n_inverted);
       return (activeHigh ^ reading);
     }
 	
-	static const uint8_t DEBOUNCE_TIME = 88;  // ms/10 (88 = 880ms); max. 225 (2250 ms)
+	static const uint8_t DEBOUNCE_TIME = 88;  // ms
 };
 
 #endif

--- a/libraries/src/HBWired.cpp
+++ b/libraries/src/HBWired.cpp
@@ -385,10 +385,10 @@ void HBWChannel::loop(HBWDevice* device, uint8_t channel) {};
 void HBWChannel::afterReadConfig() {};
 
 // default logging/feedback functions
-void HBWChannel::setFeedback(HBWDevice* device, boolean loggingEnabled) {
+void HBWChannel::setFeedback(HBWDevice* device, boolean loggingEnabled, uint16_t loggingTime) {
   if (!nextFeedbackDelay && loggingEnabled) {
     lastFeedbackTime = millis();
-    nextFeedbackDelay = device->getLoggingTime() * 100;
+    nextFeedbackDelay = loggingTime ? loggingTime : device->getLoggingTime() * 100;
   }
 };
 void HBWChannel::checkFeedback(HBWDevice* device, uint8_t channel) {

--- a/libraries/src/HBWired.h
+++ b/libraries/src/HBWired.h
@@ -44,7 +44,7 @@ class HBWChannel {
   protected:
     uint32_t lastFeedbackTime;  // when did we send the last feedback?
     uint16_t nextFeedbackDelay; // 0 -> no feedback pending
-    void setFeedback(HBWDevice*, boolean loggingEnabled);  //  set feedback trigger
+    void setFeedback(HBWDevice*, boolean loggingEnabled, uint16_t loggingTime = 0);  //  set feedback trigger
     void checkFeedback(HBWDevice*, uint8_t channel);  //  send sendInfoMessage, if feedback trigger is set
     void clearFeedback();  //  reset/init feedback trigger values
 };


### PR DESCRIPTION
setFeedback / notify allows to pass different loggingTime, to what is set in device config. It's an optional parameter, to maintain old behaviour.